### PR TITLE
update cnpj directive with strict mode dependency injection

### DIFF
--- a/validate-cnpj-directive.js
+++ b/validate-cnpj-directive.js
@@ -12,7 +12,7 @@
    * @param {ngModel} model The Model to bind
    * @returns {boolean/'undefined'}
    */
-    .directive('validateCnpj', function ($compile) {
+    .directive('validateCnpj', ['$compile', function ($compile) {
       return {
         require: 'ngModel',
         scope: { 'validateCnpj': '=' },
@@ -116,6 +116,6 @@
 
         }
       };
-    });
+    }]);
 
 }).call(this);


### PR DESCRIPTION
Hello.
Using this directive with a modern webpack can give the unknown provider error.
Webpack in production mode minify all the code. With that the $compile parameter inside cnpj directive turns to a variable that has no reference to the $compile function.
Adding the strict mode, fix this error.

The AngularJS documentation related to this case.
https://docs.angularjs.org/guide/production